### PR TITLE
fix memory leak in CglPreprocess::someFixed.

### DIFF
--- a/Cgl/src/CglPreProcess/CglPreProcess.cpp
+++ b/Cgl/src/CglPreProcess/CglPreProcess.cpp
@@ -6673,6 +6673,7 @@ CglPreProcess::someFixed(OsiSolverInterface & model,
       newModel->setColUpper(iColumn,lower[iColumn]);
     }
   }
+  delete [] sort;
   return newModel;
 }
 // If we have a cutoff - fix variables


### PR DESCRIPTION
sort was never freed.

@jjhforrest If you prefer other ways of contribution: please let me know.